### PR TITLE
Work on setting ODR (Output Data Rate) of the Accelerometer

### DIFF
--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -169,6 +169,33 @@ bool Adafruit_LSM303_Accel_Unified::begin()
   return true;
 }
 
+
+/**************************************************************************/
+/*!
+    @brief  Set the Output Data Rate (ODR) of the accelerometer
+*/
+/**************************************************************************/
+bool Adafruit_LSM303_Accel_Unified::setOdr(lsm303AccelRate odr)
+{
+  uint8_t reg, value;
+
+  // Enable I2C
+  Wire.begin();
+
+  // Check odr value validity
+  if ( (odr < LSM303_ACCELRATE_POWERDOWN) || (odr > LSM303_ACCELRATE_NA) )
+    return false;
+
+  value = (odr << 4) & 0x70;
+  reg = read8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A);
+  reg = (reg & 0x8F) | value;
+  Serial.println(reg, HEX);
+  write8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A, reg);
+
+  return true;
+}
+
+
 /**************************************************************************/
 /*! 
     @brief  Gets the most recent sensor event

--- a/Adafruit_LSM303_U.cpp
+++ b/Adafruit_LSM303_U.cpp
@@ -189,7 +189,7 @@ bool Adafruit_LSM303_Accel_Unified::setOdr(lsm303AccelRate odr)
   value = (odr << 4) & 0x70;
   reg = read8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A);
   reg = (reg & 0x8F) | value;
-  Serial.println(reg, HEX);
+  //Serial.println(reg, HEX);
   write8(LSM303_ADDRESS_ACCEL, LSM303_REGISTER_ACCEL_CTRL_REG1_A, reg);
 
   return true;

--- a/Adafruit_LSM303_U.h
+++ b/Adafruit_LSM303_U.h
@@ -109,6 +109,22 @@
 /*=========================================================================*/
 
 /*=========================================================================
+    ACCELEROMETER UPDATE RATE SETTINGS
+    -----------------------------------------------------------------------*/
+    typedef enum
+    {
+      LSM303_ACCELRATE_POWERDOWN                = 0x0,  // Power-down mode
+      LSM303_ACCELRATE_10HZ                     = 0x1,  // 10Hz
+      LSM303_ACCELRATE_50HZ                     = 0x2,  // 50Hz
+      LSM303_ACCELRATE_100HZ                    = 0x3,  // 100Hz
+      LSM303_ACCELRATE_200HZ                    = 0x4,  // 200Hz
+      LSM303_ACCELRATE_400HZ                    = 0x5,  // 400Hz
+      LSM303_ACCELRATE_800HZ                    = 0x6,  // 800Hz
+      LSM303_ACCELRATE_NA                       = 0x7,  // NA
+    } lsm303AccelRate;	
+/*=========================================================================*/
+
+/*=========================================================================
     MAGNETOMETER UPDATE RATE SETTINGS
     -----------------------------------------------------------------------*/
     typedef enum
@@ -160,6 +176,7 @@ class Adafruit_LSM303_Accel_Unified : public Adafruit_Sensor
     Adafruit_LSM303_Accel_Unified(int32_t sensorID = -1);
   
     bool begin(void);
+    bool setOdr(lsm303AccelRate odr);
     bool getEvent(sensors_event_t*);
     void getSensor(sensor_t*);
 


### PR DESCRIPTION
- Add a method setOdr() to set the Output Data Rate of the Accelerometer.

Lowest ODR values save energy.